### PR TITLE
Fix typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ php artisan vendor:publish --tag=pgsql-ltree-migration
 To add a string `path` column with and an index, use the following code:
 
 ```php
-$table->string('path')->nullable()->index();;
+$table->string('path')->nullable()->index();
 ```
 
 ## 🚊 Usage


### PR DESCRIPTION
Typo fixed 
from `$table->string('path')->nullable()->index();;` to `$table->string('path')->nullable()->index();`