### PR TITLE
Fix nested model instantiation during boot (Laravel 13)

### DIFF
--- a/src/AsTree.php
+++ b/src/AsTree.php
@@ -214,7 +214,7 @@ trait AsTree
      */
     protected static function shouldAssignPathDuringInsert(): bool
     {
-        $model = new static();
+        $model = (new \ReflectionClass(static::class))->newInstanceWithoutConstructor();
 
         if ($model->getIncrementing() && $model->getPathSourceColumn() === $model->getKeyName()) {
             return false;


### PR DESCRIPTION
## Problem

Laravel 13 introduced a breaking change that [disallows creating model instances while the model is being booted](https://laravel.com/docs/13.x/upgrade#model-booting-and-nested-instantiation), throwing a `LogicException`:

> The [Illuminate\Database\Eloquent\Model::bootIfNotBooted] method may not be called on model [App\Models\Structure] while it is being booted.

The `AsTree::shouldAssignPathDuringInsert()` method uses `new static()` to inspect model properties. This method is called from `assignPathOnEvent()`, which is called from `bootAsTree()` — creating a nested instantiation during the boot cycle.

## Solution

Replace `new static()` with `ReflectionClass::newInstanceWithoutConstructor()`. This reads the model's property defaults (`$incrementing`, `$primaryKey`) without invoking the constructor and without triggering `bootIfNotBooted()`.

## Before / After

```php
// Before (breaks on Laravel 13)
$model = new static();

// After (works on all Laravel versions)
$model = (new \ReflectionClass(static::class))->newInstanceWithoutConstructor();
```

The property getters (`getIncrementing()`, `getPathSourceColumn()`, `getKeyName()`) only read class-level property defaults, so they work correctly without constructor initialization.

## Test plan

- Verified on a Laravel 13.2.0 application using `AsTree` on an Eloquent model
- Model boot completes without `LogicException`
- Tree path assignment (both `creating` and `created` events) works correctly
- All existing project tests pass